### PR TITLE
Add production config example + systemd unit for clemetsen.no stack

### DIFF
--- a/deploy/nginY.service
+++ b/deploy/nginY.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=nginY reverse proxy
+After=network.target docker.service
+
+[Service]
+Type=simple
+# Adjust these two paths to wherever installation.sh built nginY.
+WorkingDirectory=/opt/nginY/build
+ExecStart=/opt/nginY/build/nginY
+Restart=on-failure
+RestartSec=2
+User=nginy
+Group=nginy
+# Bind to 80/443 as a non-root user.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target

--- a/nginy.prod.conf.example
+++ b/nginy.prod.conf.example
@@ -1,0 +1,42 @@
+# Example production config for the clemetsen.no stack:
+#   nginY (native, this host) -> {clemetsenSite, SindreSite, nginY-backend} (docker containers)
+#
+# Copy to nginy.conf next to the built binary and fill in real certificate paths.
+# ssl_password_file is only needed for passphrase-protected keys -- omit it
+# entirely for certbot-issued certs (FileReader::getPassword treats a missing
+# file as "no password" and SSLContext skips the passwd callback).
+
+server {
+    server_name clemetsen.no;
+    listen 80;
+    listen 443 ssl;
+
+    ssl_certificate     /etc/nginY/certs/clemetsen.no/fullchain.pem;
+    ssl_certificate_key /etc/nginY/certs/clemetsen.no/privkey.pem;
+
+    # GitHub webhook + upload API -> nginY-backend (Flask/gunicorn container)
+    location /github/webhook {
+        proxy_pass http://127.0.0.1:8000;
+    }
+    location /api {
+        proxy_pass http://127.0.0.1:8000;
+    }
+
+    # Everything else -> clemetsenSite (nginx container)
+    location / {
+        proxy_pass http://127.0.0.1:8081;
+    }
+}
+
+server {
+    server_name sindreclemetsen.no;
+    listen 80;
+    listen 443 ssl;
+
+    ssl_certificate     /etc/nginY/certs/sindreclemetsen.no/fullchain.pem;
+    ssl_certificate_key /etc/nginY/certs/sindreclemetsen.no/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8082;
+    }
+}


### PR DESCRIPTION
## Summary
- `nginy.prod.conf.example` — two vhosts (`clemetsen.no`, `sindreclemetsen.no` — update the latter if the real domain differs) routing `/github/webhook` and `/api` to the Flask backend on `127.0.0.1:8000`, and everything else to each site's container (`8081`/`8082`). No nginY code changes needed — `ServerConfig`/`ProxyConnection` already support per-vhost `location`+`proxy_pass` and longest-prefix matching.
- `deploy/nginY.service` — systemd unit to run the `installation.sh` build natively, with `CAP_NET_BIND_SERVICE` so it can bind 80/443 as a non-root user.

Part of the nginY + nginY-backend + clemetsenSite + SindreSite auto-deploy stack — see [nginY-backend](https://github.com/SanderCLE18/nginY-backend)'s README for the full picture.

**Heads up (not changed here, flagging for awareness):** `WebServer::consoleInput()` reads `exit` from stdin to stop the server. Under systemd (no attached TTY) `std::cin` hits EOF immediately, and since the loop doesn't check the stream's state, this will busy-loop on failed reads. Worth a look before running this unit long-term — happy to patch it if wanted, kept out of this PR since it's unrelated to config.

## Test plan
- [ ] Compiled and ran the actual `ServerConfig::parseConfig` against `nginy.prod.conf.example` — parses both vhosts, all three `clemetsen.no` locations (`/github/webhook`, `/api`, `/`), and the one `sindreclemetsen.no` location correctly, with expected host/port/cert/key values
- [ ] Fill in real cert paths and confirm nginY starts and proxies correctly on the actual host