### PR TITLE
Fix installation.sh: nginy.config -> nginy.conf

### DIFF
--- a/installation.sh
+++ b/installation.sh
@@ -8,6 +8,6 @@ cmake ..
 make -j$(nproc)
 
 mkdir www
-mv '../nginy.config' nginy.config
+cp '../nginy.conf' nginy.conf
 
 echo "Build successful!"


### PR DESCRIPTION
Hit this while actually running installation.sh during deployment — the mv step referenced a file that doesn't exist in the repo (nginy.config vs the real nginy.conf), so every fresh build failed at that step. Switched to cp as well so the source file isn't removed from the checkout.