### PR TITLE
Fix build on case-sensitive filesystems (Linux)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 CMakeUserPresets.json
+build/
 
 # CLion
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ add_executable(nginY_tests
         tests/network/connections/test_HttpConnection.cpp
         tests/network/connections/gTestConnection.cpp
         tests/network/connections/gTestConnectionParser.h
-        tests/network/socket/GTestSocketFactory.h
+        tests/network/socket/gTestSocketFactory.h
         tests/network/socket/test_PosixSocketFactory.cpp
         tests/core/test_WebServer.cpp
 )

--- a/installation.sh
+++ b/installation.sh
@@ -5,7 +5,7 @@ mkdir build && cd build
 
 echo "Running CMake..."
 cmake ..
-make -j$(nproc)
+make nginY -j$(nproc)
 
 mkdir www
 cp '../nginy.conf' nginy.conf

--- a/tests/core/test_Threadpool.cpp
+++ b/tests/core/test_Threadpool.cpp
@@ -2,7 +2,7 @@
 // Created by Sande on 20.03.2026.
 //
 #include <gtest/gtest.h>
-#include "core/Threadpool.h"
+#include "core/ThreadPool.h"
 
 
 TEST(ThreadPoolTest, SubmitReturnsCorrectFuture) {


### PR DESCRIPTION
## Summary
Hit these while actually building and running this on the deployment box (Linux Mint, ext4 - case-sensitive):

- `CMakeLists.txt` referenced `tests/network/socket/GTestSocketFactory.h` (capital G) but the file on disk is `gTestSocketFactory.h`, matching the `gTest*.h` convention used elsewhere (`gTestConnectionParser.h`, `gTestConnection.cpp`). Silently fine on case-insensitive filesystems, hard build failure on Linux.
- Same issue in `test_Threadpool.cpp`: `#include "core/Threadpool.h"` vs the real `core/ThreadPool.h`.
- `installation.sh` now builds the `nginY` target specifically instead of the default `all` target, since `nginY_tests` currently fails to compile for unrelated reasons (see issue below) and shouldn't block the documented install path.
- Added `build/` to `.gitignore`.

## Separate issue, not fixed here
`tests/core/test_WebServer.cpp` doesn't compile against the current `WebServer` API — it calls `server->createClientThread(...)`, which doesn't exist anymore (the real methods are `createHttpClientThread`/`createHttpsClientThread`), and its `gTestSocketFactory` mock is missing an override for `SocketFactory::createListenSocket(host, port)`, making it abstract. Looks like the test was never updated after `WebServer` was refactored to split HTTP/HTTPS handling. Didn't want to guess at the intended test behavior, so left this for you to fix deliberately — happy to take a pass at it if you point me at what the tests should actually assert.

## Test plan
- [x] `rm -rf build && bash installation.sh` completes with `Build successful!` and produces a working `build/nginY` binary